### PR TITLE
 Fix L4T version parsing to include patch version in header fetch tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,8 @@ $(BUILD_DIR)/$(DTBO): $(DTS) $(DT_HEADER) | $(BUILD_DIR)
 	@echo "  CPP     $<"
 	@$(CPP) $(CPP_FLAGS) -o $(BUILD_DIR)/$(DTS:.dts=.dts.preprocessed) $<
 	@# DTS defaults to 22pin (JetPack 6.2.2+). Patch to 24pin for L4T < 36.5.
-	@if [ "$(L4T_MAJOR)" -lt 36 ] 2>/dev/null || { [ "$(L4T_MAJOR)" -eq 36 ] && [ "$(L4T_MINOR)" -lt 5 ]; }; then \
-		echo "  PATCH   jetson-header-name -> 24pin (L4T $(L4T_MAJOR).$(L4T_MINOR))"; \
+	@if [ $$(($(L4T_MAJOR) * 100 + $(L4T_MINOR))) -lt 3605 ]; then \
+		echo "  PATCH   jetson-header-name -> 24pin ($(L4T_TAG))"; \
 		sed -i 's|Jetson 22pin CSI Connector|Jetson 24pin CSI Connector|' \
 			$(BUILD_DIR)/$(DTS:.dts=.dts.preprocessed); \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,9 @@ CPP_FLAGS := -nostdinc -undef -D__DTS__ -x assembler-with-cpp \
              -I$(LOCAL_INCLUDE) -I$(KERNEL_INCLUDE)
 DTC_FLAGS := -@ -I dts -O dtb -Wno-unit_address_vs_reg
 
-# --- L4T version (parsed once, used for header fetch and DTS patching) ---
+# --- L4T version (used for DTS patching) ---
 L4T_MAJOR := $(shell grep -oP 'R\K[0-9]+' /etc/nv_tegra_release | head -1)
 L4T_MINOR := $(shell grep -oP 'REVISION:\s*\K[0-9]+' /etc/nv_tegra_release | head -1)
-L4T_TAG   := jetson_$(L4T_MAJOR).$(L4T_MINOR)
 
 # --- Kernel module ---
 KDIR      := /lib/modules/$(shell uname -r)/build
@@ -49,7 +48,7 @@ module: $(BUILD_DIR)/nv_ar0234.ko
 
 $(DT_HEADER): | $(BUILD_DIR)
 	@echo "  FETCH   NVIDIA device tree headers"
-	@./scripts/fetch-nvidia-headers.sh $(LOCAL_INCLUDE) $(L4T_TAG)
+	@./scripts/fetch-nvidia-headers.sh $(LOCAL_INCLUDE)
 
 $(CONFTEST_H): | $(BUILD_DIR)
 	@echo "  GEN     conftest.h"
@@ -61,7 +60,7 @@ $(BUILD_DIR)/$(DTBO): $(DTS) $(DT_HEADER) | $(BUILD_DIR)
 	@$(CPP) $(CPP_FLAGS) -o $(BUILD_DIR)/$(DTS:.dts=.dts.preprocessed) $<
 	@# DTS defaults to 22pin (JetPack 6.2.2+). Patch to 24pin for L4T < 36.5.
 	@if [ $$(($(L4T_MAJOR) * 100 + $(L4T_MINOR))) -lt 3605 ]; then \
-		echo "  PATCH   jetson-header-name -> 24pin ($(L4T_TAG))"; \
+		echo "  PATCH   jetson-header-name -> 24pin (L4T $(L4T_MAJOR).$(L4T_MINOR))"; \
 		sed -i 's|Jetson 22pin CSI Connector|Jetson 24pin CSI Connector|' \
 			$(BUILD_DIR)/$(DTS:.dts=.dts.preprocessed); \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ DTC_FLAGS := -@ -I dts -O dtb -Wno-unit_address_vs_reg
 # --- L4T version (parsed once, used for header fetch and DTS patching) ---
 L4T_MAJOR := $(shell grep -oP 'R\K[0-9]+' /etc/nv_tegra_release | head -1)
 L4T_MINOR := $(shell grep -oP 'REVISION:\s*\K[0-9]+' /etc/nv_tegra_release | head -1)
-L4T_TAG   := jetson_$(L4T_MAJOR).$(L4T_MINOR)
+L4T_PATCH := $(shell grep -oP 'REVISION:\s*[0-9]+\.\K[0-9]+' /etc/nv_tegra_release | head -1)
+L4T_TAG   := jetson_$(L4T_MAJOR).$(L4T_MINOR)$(if $(L4T_PATCH),.$(L4T_PATCH))
 
 # --- Kernel module ---
 KDIR      := /lib/modules/$(shell uname -r)/build

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,7 @@ DTC_FLAGS := -@ -I dts -O dtb -Wno-unit_address_vs_reg
 # --- L4T version (parsed once, used for header fetch and DTS patching) ---
 L4T_MAJOR := $(shell grep -oP 'R\K[0-9]+' /etc/nv_tegra_release | head -1)
 L4T_MINOR := $(shell grep -oP 'REVISION:\s*\K[0-9]+' /etc/nv_tegra_release | head -1)
-L4T_PATCH := $(shell grep -oP 'REVISION:\s*[0-9]+\.\K[0-9]+' /etc/nv_tegra_release | head -1)
-L4T_TAG   := jetson_$(L4T_MAJOR).$(L4T_MINOR)$(if $(L4T_PATCH),.$(L4T_PATCH))
+L4T_TAG   := jetson_$(L4T_MAJOR).$(L4T_MINOR)
 
 # --- Kernel module ---
 KDIR      := /lib/modules/$(shell uname -r)/build

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Connect camera to `cam0` port.
 Install required tools:
 
 ```bash
-sudo apt install -y dkms
+sudo apt install -y --no-install-recommends dkms
 ```
 
 Clone the repository to your Jetson machine and navigate to the cloned directory:

--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
-# ar0234 MIPI NVIDIA driver
+# AR0234 MIPI NVIDIA driver
 
 ![JetPack 6.2.1](https://img.shields.io/badge/JetPack_6.2.1-L4T_36.4.4-brightgreen?logo=nvidia&logoColor=white)
 ![JetPack 6.2.2](https://img.shields.io/badge/JetPack_6.2.2-L4T_36.5.0-brightgreen?logo=nvidia&logoColor=white)
 
-## Quickstart
+NVIDIA Jetson kernel driver for Onsemi AR0234CS — a 2.3 MP global shutter 1/2.6" CMOS sensor.
 
-Connect camera to `cam0` port.
+- 2-lane MIPI CSI-2
+- 10-bit RAW output
+- 1920×1200 @ 30 fps
 
 > [!NOTE]
 > Currently, only `cam0` port support is implemented.
 
----
+## Setup
 
 Install required tools:
 
@@ -18,7 +20,7 @@ Install required tools:
 sudo apt install -y --no-install-recommends dkms
 ```
 
-Clone the repository to your Jetson machine and navigate to the cloned directory:
+Clone this repository:
 
 ```bash
 cd ~
@@ -26,36 +28,30 @@ git clone https://github.com/Kurokesu/ar0234-mipi-nvidia.git
 cd ar0234-mipi-nvidia/
 ```
 
----
-
-Build and install:
+Run setup script:
 
 ```bash
 sudo ./setup.sh
 ```
 
-The setup script:
-- Fetches NVIDIA device tree headers
-- Installs the kernel module via [DKMS](https://github.com/dell/dkms), which automatically rebuilds the module and device tree overlay when the kernel is updated
-- Builds and installs the device tree overlay (`.dtbo`) to `/boot` via a DKMS post-install hook
+Setup script:
+- Fetches NVIDIA device tree headers required for build
+- Builds and installs kernel module via [DKMS](https://github.com/dell/dkms)
+- Builds and copies device tree overlay (`.dtbo`) to `/boot`
 
----
-
-To install the ISP tuning file, run:
+Optionally, install the ISP tuning file:
 
 ```bash
 sudo cp ./tuning/camera_overrides.isp /var/nvidia/nvcam/settings
 ```
 
-To uninstall and restore the default ISP parameters, remove the overrides file:
+To restore default ISP parameters, remove the overrides file:
 
 ```bash
 sudo rm /var/nvidia/nvcam/settings/camera_overrides.isp
 ```
 
----
-
-Use the Jetson-IO tool to configure the CSI connector:
+Use Jetson-IO to configure the CSI connector:
 
 ```bash
 sudo /opt/nvidia/jetson-io/jetson-io.py
@@ -71,9 +67,7 @@ Navigate through the menu:
 4. Save pin changes
 5. Save and reboot to reconfigure pins
 
----
-
-After reboot verify that the sensor is detected over I2C:
+After reboot, verify sensor is detected:
 
 ```bash
 sudo dmesg | grep ar0234
@@ -99,17 +93,16 @@ nvgstcapture-1.0 --sensor-id 0
 
 ## Test mode
 
-The sensor has a built-in test pattern generator that can be used to verify data validity.
+AR0234 has a built-in test pattern generator for verifying data validity.
 
-After running `sudo ./setup.sh` the driver is installed and loaded automatically at boot.  
-The `test_mode` module parameter can then be controlled at runtime via sysfs:
+Enable test pattern:
 
 ```bash
 # 100% color-bar test pattern (test_mode = 2)
 echo 2 | sudo tee /sys/module/nv_ar0234/parameters/test_mode
 ```
 
-To turn the test pattern off:
+Turn test pattern off:
 
 ```bash
 echo 0 | sudo tee /sys/module/nv_ar0234/parameters/test_mode
@@ -129,11 +122,11 @@ For manual builds without DKMS:
 
 ```bash
 make              # build everything (dtbo + kernel module)
-sudo make install # copy dtbo to /boot, rmmod + insmod the module
+sudo make install # copy dtbo to /boot, rmmod + insmod
 ```
 
 > [!NOTE]
-> The module is loaded immediately via `insmod` but won't persist across reboots. Use `sudo ./setup.sh` for permanent installation via DKMS.
+> Module is loaded immediately via `insmod` but won't persist across reboots. Use `sudo ./setup.sh` for permanent installation via DKMS.
 
 Individual targets:
 
@@ -143,4 +136,4 @@ make module    # build only the kernel module
 make clean     # remove build artifacts
 ```
 
-All build artifacts are placed in the `./build` directory.
+Build artifacts are placed in `./build`.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ar0234 MIPI NVIDIA driver
 
-![JetPack 6.2.1](https://img.shields.io/badge/JetPack_6.2.1-L4T_36.4.4-green?logo=nvidia&logoColor=white)
-![JetPack 6.2.2](https://img.shields.io/badge/JetPack_6.2.2-L4T_36.5.0-green?logo=nvidia&logoColor=white)
+![JetPack 6.2.1](https://img.shields.io/badge/JetPack_6.2.1-L4T_36.4.4-brightgreen?logo=nvidia&logoColor=white)
+![JetPack 6.2.2](https://img.shields.io/badge/JetPack_6.2.2-L4T_36.5.0-brightgreen?logo=nvidia&logoColor=white)
 
 ## Quickstart
 

--- a/dkms.conf
+++ b/dkms.conf
@@ -2,7 +2,7 @@
 # Copyright (c) 2026, UAB Kurokesu. All rights reserved.
 
 PACKAGE_NAME="nv-ar0234"
-PACKAGE_VERSION="2.0.6"
+PACKAGE_VERSION="0.1.0"
 
 BUILT_MODULE_NAME[0]="nv_ar0234"
 DEST_MODULE_LOCATION[0]="/updates/drivers/media/i2c"

--- a/dkms.conf
+++ b/dkms.conf
@@ -4,8 +4,8 @@
 PACKAGE_NAME="nv-ar0234"
 PACKAGE_VERSION="0.1.0"
 
-BUILT_MODULE_NAME[0]="nv_ar0234"
-DEST_MODULE_LOCATION[0]="/updates/drivers/media/i2c"
+BUILT_MODULE_NAME="nv_ar0234"
+DEST_MODULE_LOCATION="/updates/drivers/media/i2c"
 
 # Generate Kbuild + conftest.h, then build the module
 MAKE="cd ${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build && \

--- a/dkms.postinst
+++ b/dkms.postinst
@@ -24,7 +24,7 @@ cpp -nostdinc -undef -D__DTS__ -x assembler-with-cpp \
 L4T_MAJOR=$(grep -oP 'R\K[0-9]+' /etc/nv_tegra_release | head -1)
 L4T_MINOR=$(grep -oP 'REVISION:\s*\K[0-9]+' /etc/nv_tegra_release | head -1)
 
-if [ "$L4T_MAJOR" -lt 36 ] 2>/dev/null || { [ "$L4T_MAJOR" -eq 36 ] && [ "$L4T_MINOR" -lt 5 ]; }; then
+if [ $((L4T_MAJOR * 100 + L4T_MINOR)) -lt 3605 ]; then
     echo "Patching jetson-header-name for L4T ${L4T_MAJOR}.${L4T_MINOR} (24pin)"
     sed -i 's|Jetson 22pin CSI Connector|Jetson 24pin CSI Connector|' "$PREPROCESSED"
 fi

--- a/scripts/fetch-nvidia-headers.sh
+++ b/scripts/fetch-nvidia-headers.sh
@@ -18,21 +18,11 @@ GITLAB_BASE="https://gitlab.com/nvidia/nv-tegra/device/hardware/nvidia/t23x-publ
 
 # Auto-detect tag from /etc/nv_tegra_release if not provided
 if [ -z "$TAG" ]; then
-    RELEASE_FILE="/etc/nv_tegra_release"
-    if [ ! -f "$RELEASE_FILE" ]; then
-        echo "ERROR: $RELEASE_FILE not found -- is this a Jetson?" >&2
-        exit 1
-    fi
-    L4T_MAJOR=$(grep -oP 'R\K[0-9]+' "$RELEASE_FILE" | head -1)
-    L4T_MINOR=$(grep -oP 'REVISION:\s*\K[0-9]+' "$RELEASE_FILE" | head -1)
-    if [ -z "$L4T_MAJOR" ] || [ -z "$L4T_MINOR" ]; then
-        echo "ERROR: could not parse L4T version from $RELEASE_FILE" >&2
-        exit 1
-    fi
-    TAG="jetson_${L4T_MAJOR}.${L4T_MINOR}"
+    L4T_MAJOR=$(grep -oP 'R\K[0-9]+' /etc/nv_tegra_release | head -1)
+    L4T_MINOR=$(grep -oP 'REVISION:\s*\K[0-9]+' /etc/nv_tegra_release | head -1)
+    L4T_PATCH=$(grep -oP 'REVISION:\s*[0-9]+\.\K[0-9]+' /etc/nv_tegra_release | head -1)
+    TAG="jetson_${L4T_MAJOR}.${L4T_MINOR}${L4T_PATCH:+.${L4T_PATCH}}"
 fi
-
-echo "  L4T tag: $TAG"
 
 REPO_PATH="include/platforms/dt-bindings/tegra234-p3767-0000-common.h"
 LOCAL_FILE="$OUT_DIR/dt-bindings/tegra234-p3767-0000-common.h"

--- a/scripts/fetch-nvidia-headers.sh
+++ b/scripts/fetch-nvidia-headers.sh
@@ -5,34 +5,14 @@
 # Fetch NVIDIA public device tree headers from GitLab.
 #
 # Usage:
-#   ./scripts/fetch-nvidia-headers.sh <output_dir> [l4t_tag]
-#
-# If l4t_tag is not provided, it is auto-detected from /etc/nv_tegra_release.
+#   ./scripts/fetch-nvidia-headers.sh <output_dir> <l4t_tag>
 
 set -e
 
-OUT_DIR="${1:?Usage: $0 <output_dir> [l4t_tag]}"
-TAG="${2:-}"
+OUT_DIR="${1:?Usage: $0 <output_dir> <l4t_tag>}"
+TAG="${2:?Usage: $0 <output_dir> <l4t_tag>}"
 
 GITLAB_BASE="https://gitlab.com/nvidia/nv-tegra/device/hardware/nvidia/t23x-public-dts/-/raw"
-
-# Auto-detect tag from /etc/nv_tegra_release if not provided
-if [ -z "$TAG" ]; then
-    RELEASE_FILE="/etc/nv_tegra_release"
-    if [ ! -f "$RELEASE_FILE" ]; then
-        echo "ERROR: $RELEASE_FILE not found -- is this a Jetson?" >&2
-        exit 1
-    fi
-    L4T_MAJOR=$(grep -oP 'R\K[0-9]+' "$RELEASE_FILE" | head -1)
-    L4T_MINOR=$(grep -oP 'REVISION:\s*\K[0-9]+' "$RELEASE_FILE" | head -1)
-    if [ -z "$L4T_MAJOR" ] || [ -z "$L4T_MINOR" ]; then
-        echo "ERROR: could not parse L4T version from $RELEASE_FILE" >&2
-        exit 1
-    fi
-    TAG="jetson_${L4T_MAJOR}.${L4T_MINOR}"
-fi
-
-echo "  L4T tag: $TAG"
 
 REPO_PATH="include/platforms/dt-bindings/tegra234-p3767-0000-common.h"
 LOCAL_FILE="$OUT_DIR/dt-bindings/tegra234-p3767-0000-common.h"

--- a/scripts/fetch-nvidia-headers.sh
+++ b/scripts/fetch-nvidia-headers.sh
@@ -5,14 +5,34 @@
 # Fetch NVIDIA public device tree headers from GitLab.
 #
 # Usage:
-#   ./scripts/fetch-nvidia-headers.sh <output_dir> <l4t_tag>
+#   ./scripts/fetch-nvidia-headers.sh <output_dir> [l4t_tag]
+#
+# If l4t_tag is not provided, it is auto-detected from /etc/nv_tegra_release.
 
 set -e
 
-OUT_DIR="${1:?Usage: $0 <output_dir> <l4t_tag>}"
-TAG="${2:?Usage: $0 <output_dir> <l4t_tag>}"
+OUT_DIR="${1:?Usage: $0 <output_dir> [l4t_tag]}"
+TAG="${2:-}"
 
 GITLAB_BASE="https://gitlab.com/nvidia/nv-tegra/device/hardware/nvidia/t23x-public-dts/-/raw"
+
+# Auto-detect tag from /etc/nv_tegra_release if not provided
+if [ -z "$TAG" ]; then
+    RELEASE_FILE="/etc/nv_tegra_release"
+    if [ ! -f "$RELEASE_FILE" ]; then
+        echo "ERROR: $RELEASE_FILE not found -- is this a Jetson?" >&2
+        exit 1
+    fi
+    L4T_MAJOR=$(grep -oP 'R\K[0-9]+' "$RELEASE_FILE" | head -1)
+    L4T_MINOR=$(grep -oP 'REVISION:\s*\K[0-9]+' "$RELEASE_FILE" | head -1)
+    if [ -z "$L4T_MAJOR" ] || [ -z "$L4T_MINOR" ]; then
+        echo "ERROR: could not parse L4T version from $RELEASE_FILE" >&2
+        exit 1
+    fi
+    TAG="jetson_${L4T_MAJOR}.${L4T_MINOR}"
+fi
+
+echo "  L4T tag: $TAG"
 
 REPO_PATH="include/platforms/dt-bindings/tegra234-p3767-0000-common.h"
 LOCAL_FILE="$OUT_DIR/dt-bindings/tegra234-p3767-0000-common.h"

--- a/scripts/fetch-nvidia-headers.sh
+++ b/scripts/fetch-nvidia-headers.sh
@@ -21,6 +21,8 @@ if [ -z "$TAG" ]; then
     L4T_MAJOR=$(grep -oP 'R\K[0-9]+' /etc/nv_tegra_release | head -1)
     L4T_MINOR=$(grep -oP 'REVISION:\s*\K[0-9]+' /etc/nv_tegra_release | head -1)
     L4T_PATCH=$(grep -oP 'REVISION:\s*[0-9]+\.\K[0-9]+' /etc/nv_tegra_release | head -1)
+    # NVIDIA omits .0 patch in GitLab tags (e.g. jetson_36.5, not jetson_36.5.0)
+    if [ "$L4T_PATCH" = "0" ]; then L4T_PATCH=""; fi
     TAG="jetson_${L4T_MAJOR}.${L4T_MINOR}${L4T_PATCH:+.${L4T_PATCH}}"
 fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -18,7 +18,7 @@ DKMS_SRC="/usr/src/${PACKAGE_NAME}-${VERSION}"
 # --- Check prerequisites ---
 
 if ! command -v dkms &>/dev/null; then
-    echo "Error: dkms is not installed. Install it with: sudo apt install dkms"
+    echo "Error: dkms is not installed. Install it with: sudo apt install --no-install-recommends dkms"
     exit 1
 fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -22,11 +22,12 @@ if ! command -v dkms &>/dev/null; then
     exit 1
 fi
 
-# --- Remove old DKMS registration if present ---
+# --- Remove previous DKMS registration if present ---
 
-if dkms status "${PACKAGE_NAME}/${VERSION}" 2>/dev/null | grep -q .; then
-    echo "Removing previous DKMS registration for ${PACKAGE_NAME}/${VERSION}..."
-    dkms remove "${PACKAGE_NAME}/${VERSION}" --all 2>/dev/null || true
+OLD_VER=$(dkms status -m "$PACKAGE_NAME" 2>/dev/null | cut -d'/' -f2 | cut -d',' -f1)
+if [ -n "$OLD_VER" ]; then
+    echo "Removing previous DKMS registration: ${PACKAGE_NAME}/${OLD_VER}"
+    dkms remove "${PACKAGE_NAME}/${OLD_VER}" --all || true
 fi
 
 # --- Back up and remove stock NVIDIA ar0234 driver if present ---


### PR DESCRIPTION
## Summary

The L4T tag auto-detection in `fetch-nvidia-headers.sh` only extracted major and minor components from `/etc/nv_tegra_release`, constructing tags like `jetson_36.4` for `REVISION: 4.4`. This caused the NVIDIA header fetch to silently resolve to the `l4t/l4t-r36.4` branch instead of the correct `jetson_36.4.4` tag, pulling stale device tree headers.
In L4T 36.4.4 (JetPack 6.2.1), NVIDIA added `-super` variants to the `JETSON_COMPATIBLE_P3768` define in `tegra234-p3767-0000-common.h` to support the Jetson Orin NX/Nano Super module refresh (`p3767-0000-super` through `p3767-0005-super`). The older `l4t/l4t-r36.4` branch does not contain these entries. Since our DTS overlay uses `JETSON_COMPATIBLE_P3768` for its `compatible` property, the overlay would not match on Super boards running L4T 36.4.4 (JetPack 6.2.1), preventing the driver from being discovered by `jetson-io` tool.
Changes:
* Fix `L4T_PATCH` extraction in `fetch-nvidia-headers.sh` auto-detection to include the patch version when constructing the GitLab tag (e.g. `jetson_36.4.4`).
* Strip `.0` patch versions from the constructed tag to match NVIDIA's GitLab naming convention (e.g. `jetson_36.5`, not `jetson_36.5.0`).
* Remove `L4T_TAG` from `Makefile` — the fetch script now handles tag construction, eliminating duplication.
* Simplify the L4T < 36.5 version check in both `Makefile` and `dkms.postinst` from a multi-condition shell expression to a single arithmetic comparison, and remove silent error suppression (`2>/dev/null`).
* Use `--no-install-recommends` when installing `dkms` to avoid pulling in ~98 MB of unnecessary generic Linux headers (Jetson already has its own tegra-specific kernel headers from JetPack).
* Align README structure and style with imx462-mipi-nvidia: add sensor description and specs, remove redundant sections, clean up formatting.

## Test plan

- [x] On L4T 36.4.4 (JetPack 6.2.1): `make clean && make dtbo` — confirm fetch output shows tag `jetson_36.4.4` and fetched header contains `-super` compatible strings
- [x] On L4T 36.5 (JetPack 6.2.2): `make clean && make dtbo` — confirm tag resolves to `jetson_36.5`
- [x] On a Jetson Orin Nano Super running `L4T 36.4.4` or `L4T 36.4.7`: run full driver setup and verify camera functionality