### PR TITLE
Update README URLs for repo rename to ar0234-jetson-driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AR0234 MIPI NVIDIA driver
+# AR0234 kernel driver for NVIDIA Jetson
 
 ![JetPack 6.2.1](https://img.shields.io/badge/JetPack_6.2.1-L4T_36.4.4-brightgreen?logo=nvidia&logoColor=white)
 ![JetPack 6.2.2](https://img.shields.io/badge/JetPack_6.2.2-L4T_36.5.0-brightgreen?logo=nvidia&logoColor=white)
@@ -21,8 +21,8 @@ Clone this repository:
 
 ```bash
 cd ~
-git clone https://github.com/Kurokesu/ar0234-mipi-nvidia.git
-cd ar0234-mipi-nvidia/
+git clone https://github.com/Kurokesu/ar0234-jetson-driver.git
+cd ar0234-jetson-driver/
 ```
 
 Run setup script:


### PR DESCRIPTION
Renaming repo to `ar0234-jetson-driver` to keep naming consistent with the rest of Kurokesu organization's Jetson driver repos.

This PR updates `README.md` references that embed the old repo name: heading and `git clone` / `cd` lines in the setup instructions. Merge after the GitHub rename so the new URLs resolve.

## For existing local clones

Existing clones keep working via GitHub's redirect, but to align with the new name:

```bash
cd ~
mv ar0234-mipi-nvidia ar0234-jetson-driver
cd ar0234-jetson-driver
git remote set-url origin https://github.com/Kurokesu/ar0234-jetson-driver.git
git fetch -v # verify